### PR TITLE
Inherit from Arduino Stream Class

### DIFF
--- a/SDI12.cpp
+++ b/SDI12.cpp
@@ -787,7 +787,7 @@ void SDI12::receiveChar()
   }
 }
 
-int SDI12_Stream::peekNextDigit()
+int SDI12::peekNextDigit()
 {
   int c;
   while (1) {

--- a/SDI12.cpp
+++ b/SDI12.cpp
@@ -127,7 +127,7 @@ SDI-12.org, official site of the SDI-12 Support Group.
 #define TRANSMITTING 3					// 0.6 value for TRANSMITTING state
 #define LISTENING 4						// 0.7 value for LISTENING state
 #define SPACING 830						// 0.8 bit timing in microseconds
-#define TIMEOUT -9999					// 0.9 value to return to indicate TIMEOUT
+int TIMEOUT -9999					// 0.9 value to return to indicate TIMEOUT
 
 SDI12 *SDI12::_activeObject = NULL;		// 0.10 pointer to active SDI12 object
 uint8_t _dataPin; 						// 0.11 reference to the data pin
@@ -377,12 +377,12 @@ void SDI12::setState(uint8_t state){
     pinMode(_dataPin,OUTPUT);
     digitalWrite(_dataPin,LOW);
     *digitalPinToPCMSK(_dataPin) &= ~(1<<digitalPinToPCMSKbit(_dataPin));
-    return(); 
+    return; 
   }
   if(state == TRANSMITTING){
     pinMode(_dataPin,OUTPUT);
     noInterrupts(); 			// supplied by Arduino.h, same as cli()
-    return(); 
+    return; 
   }
   if(state == LISTENING) {
     digitalWrite(_dataPin,LOW);

--- a/SDI12.cpp
+++ b/SDI12.cpp
@@ -110,10 +110,11 @@ SDI-12.org, official site of the SDI-12 Support Group.
 0.8 - defines value for the spacing of bits. 
 	1200 bits per second implies 833 microseconds per bit.
 	830 seems to be a reliable value given the overhead of the call.
+0.9	- defines the value to indicate a TIMEOUT has occurred from parseInt() or parseFloat()
 
-0.9 - a static pointer to the active object. See section 6. 
-0.10 - a reference to the data pin, used throughout the library
-0.11 - holds the buffer overflow status
+0.10 - a static pointer to the active object. See section 6. 
+0.11 - a reference to the data pin, used throughout the library
+0.12 - holds the buffer overflow status
 
 */
 
@@ -126,10 +127,11 @@ SDI-12.org, official site of the SDI-12 Support Group.
 #define TRANSMITTING 3					// 0.6 value for TRANSMITTING state
 #define LISTENING 4						// 0.7 value for LISTENING state
 #define SPACING 830						// 0.8 bit timing in microseconds
+#define TIMEOUT -9999					// 0.9 value to return to indicate TIMEOUT
 
-SDI12 *SDI12::_activeObject = NULL;		// 0.9 pointer to active SDI12 object
-uint8_t _dataPin; 						// 0.10 reference to the data pin
-bool _bufferOverflow;					// 0.11 buffer overflow status
+SDI12 *SDI12::_activeObject = NULL;		// 0.10 pointer to active SDI12 object
+uint8_t _dataPin; 						// 0.11 reference to the data pin
+bool _bufferOverflow;					// 0.12 buffer overflow status
 
 /* =========== 1. Buffer Setup ============================================
 
@@ -782,6 +784,18 @@ void SDI12::receiveChar()
       _rxBuffer[_rxBufferTail] = newChar; 
       _rxBufferTail = (_rxBufferTail + 1) % _BUFFER_SIZE;
     }
+  }
+}
+
+int SDI12_Stream::peekNextDigit()
+{
+  int c;
+  while (1) {
+    c = timedPeek();
+    if (c < 0) return TIMEOUT; // timeout
+    if (c == '-') return c;
+    if (c >= '0' && c <= '9') return c;
+    read(); // discard non-numeric
   }
 }
 

--- a/SDI12.h
+++ b/SDI12.h
@@ -44,6 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <avr/parity.h>         // optimized parity bit handling
 #include <inttypes.h>			// integer types library
 #include <Arduino.h>            // Arduino core library
+#include <Stream.h>				// Arduino Stream library
 
 class SDI12
 {
@@ -67,6 +68,7 @@ public:
   int peek();				// reveals next byte in buffer without consuming
   int read();				// returns next byte in the buffer (consumes)
   void flush();				// clears the buffer 
+  virtual size_t write(uint8_t byte); // dummy function required to inherit from Stream
 
   bool setActive(); 		// set this instance as the active SDI-12 instance
   bool isActive();			// check if this instance is active

--- a/SDI12.h
+++ b/SDI12.h
@@ -58,6 +58,7 @@ private:
   void receiveChar();			// used by the ISR to grab a char from data line
   
 public:
+  int TIMEOUT
   SDI12(uint8_t dataPin);		// constructor
   ~SDI12();						// destructor
   void begin();					// enable SDI-12 object

--- a/SDI12.h
+++ b/SDI12.h
@@ -58,7 +58,7 @@ private:
   void receiveChar();			// used by the ISR to grab a char from data line
   
 public:
-  int TIMEOUT
+  int TIMEOUT;
   SDI12(uint8_t dataPin);		// constructor
   ~SDI12();						// destructor
   void begin();					// enable SDI-12 object

--- a/SDI12.h
+++ b/SDI12.h
@@ -46,8 +46,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Arduino.h>            // Arduino core library
 #include <Stream.h>				// Arduino Stream library
 
-class SDI12
+class SDI12 : public Stream
 {
+protected:
+  int peekNextDigit();			// override of Stream equivalent to allow custom TIMEOUT
 private:
   static SDI12 *_activeObject;	// static pointer to active SDI12 instance
   void setState(uint8_t state); // sets the state of the SDI12 objects
@@ -68,7 +70,7 @@ public:
   int peek();				// reveals next byte in buffer without consuming
   int read();				// returns next byte in the buffer (consumes)
   void flush();				// clears the buffer 
-  virtual size_t write(uint8_t byte); // dummy function required to inherit from Stream
+  virtual size_t write(uint8_t byte){}; // dummy function required to inherit from Stream
 
   bool setActive(); 		// set this instance as the active SDI-12 instance
   bool isActive();			// check if this instance is active

--- a/examples/a_wild_card/a_wild_card.ino
+++ b/examples/a_wild_card/a_wild_card.ino
@@ -1,23 +1,51 @@
 /*
-Example A: Using the wildcard. 
+########################
+#        OVERVIEW      #
+########################
+ 
+ Example A: Using the wildcard. 
 
-This is a simple demonstration of the SDI-12 library for Arduino.
-It requests information about the attached sensor, including its address and manufacturer info. 
+ This is a simple demonstration of the SDI-12 library for Arduino.
+ It requests information about the attached sensor, including its address and manufacturer info. 
 
-The SDI-12 specification is available at: http://www.sdi-12.org/
-The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
+#########################
+#      THE CIRCUIT      #
+#########################
+ 
+ You should not have more than one SDI-12 device attached for this example.
 
-The circuit: You should not have more than one SDI-12 device attached for this example.
+ See: 
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_no_usb.png
+ or
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
 
-See: 
-https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_no_usb.png
-or
-https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
+###########################
+#      COMPATIBILITY      #
+###########################
+ 
+ This library requires the use of pin change interrupts (PCINT). 
+ Not all Arduino boards have the same pin capabilities. 
+ The known compatibile pins for common variants are shown below.
+ 
+ Arduino Uno: 	All pins. 
 
-Written by Kevin M. Smith in 2013. 
-Contact: SDI12@ethosengineering.org
+ Arduino Mega or Mega 2560:
+ 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), 
+ A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69).
+
+ Arduino Leonardo:
+ 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)
+
+#########################
+#      RESOURCES        #
+#########################
+
+ Written by Kevin M. Smith in 2013. 
+ Contact: SDI12@ethosengineering.org
+
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
 */
-
 
 #include <SDI12.h>
 

--- a/examples/b_address_change/b_address_change.ino
+++ b/examples/b_address_change/b_address_change.ino
@@ -1,21 +1,51 @@
 /*
-Example B: Changing the address of a sensor. 
+########################
+#        OVERVIEW      #
+########################
+ 
+ Example B: Changing the address of a sensor. 
  
  This is a simple demonstration of the SDI-12 library for arduino.
  It discovers the address of the attached sensor and allows you to change it.
- 
- The SDI-12 specification is available at: http://www.sdi-12.org/
- The library is available at: https://github.com/StroudCenter/arduino-SDI-12
+
+#########################
+#      THE CIRCUIT      #
+#########################
  
  The circuit: You should not have more than one SDI-12 device attached for this example. 
+ 
  See: 
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_no_usb.png
  or
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
+
+###########################
+#      COMPATIBILITY      #
+###########################
  
+ This library requires the use of pin change interrupts (PCINT). 
+ Not all Arduino boards have the same pin capabilities. 
+ The known compatibile pins for common variants are shown below.
+ 
+ Arduino Uno: 	All pins. 
+
+ Arduino Mega or Mega 2560:
+ 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), 
+ A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69).
+
+ Arduino Leonardo:
+ 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)
+
+#########################
+#      RESOURCES        #
+#########################
+
  Written by Kevin M. Smith in 2013. 
  Contact: SDI12@ethosengineering.org
- */
+
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
+*/
 
 
 #include <SDI12.h>

--- a/examples/c_check_all_addresses/c_check_all_addresses.ino
+++ b/examples/c_check_all_addresses/c_check_all_addresses.ino
@@ -1,5 +1,9 @@
 /*
-Example C: Checks all addresses for active sensors, and prints their status to the serial port. 
+########################
+#        OVERVIEW      #
+########################
+ 
+ Example C: Checks all addresses for active sensors, and prints their status to the serial port. 
  
  This is a simple demonstration of the SDI-12 library for Arduino.
  
@@ -10,18 +14,44 @@ Example C: Checks all addresses for active sensors, and prints their status to t
  
  To address a sensor, please see Example B: b_address_change.ino
  
- The SDI-12 specification is available at: http://www.sdi-12.org/
- The library is available at: https://github.com/StroudCenter/arduino-SDI-12
+#########################
+#      THE CIRCUIT      #
+#########################
+
+ You  may use one or more pre-adressed sensors.  
  
- The circuit: You  may use one or more pre-adressed sensors.  
  See:
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_usb_multiple_sensors.png
  or
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb_multiple_sensors.png
+
+###########################
+#      COMPATIBILITY      #
+###########################
  
+ This library requires the use of pin change interrupts (PCINT). 
+ Not all Arduino boards have the same pin capabilities. 
+ The known compatibile pins for common variants are shown below.
+ 
+ Arduino Uno: 	All pins. 
+
+ Arduino Mega or Mega 2560:
+ 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), 
+ A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69).
+
+ Arduino Leonardo:
+ 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)
+
+#########################
+#      RESOURCES        #
+#########################
+
  Written by Kevin M. Smith in 2013. 
  Contact: SDI12@ethosengineering.org
- */
+
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
+*/
 
 
 #include <SDI12.h>

--- a/examples/d_simple_logger/d_simple_logger.ino
+++ b/examples/d_simple_logger/d_simple_logger.ino
@@ -1,5 +1,8 @@
 /*
-Example D: Checks all addresses for active sensors, and logs data for each sensor every minute. 
+########################
+#        OVERVIEW      #
+########################
+ Example D: Checks all addresses for active sensors, and logs data for each sensor every minute. 
  
  This is a simple demonstration of the SDI-12 library for Arduino.
  
@@ -14,10 +17,12 @@ Example D: Checks all addresses for active sensors, and logs data for each senso
  
  To address a sensor, please see Example B: b_address_change.ino
  
- The SDI-12 specification is available at: http://www.sdi-12.org/
- The library is available at: https://github.com/StroudCenter/arduino-SDI-12
+#########################
+#      THE CIRCUIT      #
+#########################
  
- The circuit: You  may use one or more pre-adressed sensors.  
+ You  may use one or more pre-adressed sensors.  
+ 
  See:
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_usb_multiple_sensors.png
  or
@@ -27,9 +32,33 @@ Example D: Checks all addresses for active sensors, and logs data for each senso
  or
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
  
+###########################
+#      COMPATIBILITY      #
+###########################
+ 
+ This library requires the use of pin change interrupts (PCINT). 
+ Not all Arduino boards have the same pin capabilities. 
+ The known compatibile pins for common variants are shown below.
+ 
+ Arduino Uno: 	All pins. 
+
+ Arduino Mega or Mega 2560:
+ 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), 
+ A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69).
+
+ Arduino Leonardo:
+ 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)
+
+#########################
+#      RESOURCES        #
+#########################
+
  Written by Kevin M. Smith in 2013. 
  Contact: SDI12@ethosengineering.org
- */
+
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
+*/
 
 
 #include <SDI12.h>

--- a/examples/e_simple_parsing/e_simple_parsing.ino
+++ b/examples/e_simple_parsing/e_simple_parsing.ino
@@ -1,0 +1,321 @@
+/*
+Example E: This example demonstrates the ability to parse integers and floats from the buffer. 
+
+ It is based closely on example D, however, every other time it prints out data, it multiplies the data by a factor of 2. 
+ 
+ Time Elapsed (s), Sensor Address and ID, Measurement 1, Measurement 2, ... etc.
+ -------------------------------------------------------------------------------
+ 6,c13SENSOR ATM    311,0.62 x 2 = 1.24,19.80 x 2 = 39.60
+ 17,c13SENSOR ATM   311,0.62,19.7
+ 29,c13SENSOR ATM   311,0.62 x 2 = 1.2419.70 x 2 = 39.40
+ 41,c13SENSOR ATM   311,0.62,19.8
+ 
+ This is a trivial and nonsensical example, but it does demonstrate the ability to manipulate incoming data.
+ 
+ At this point in the example series, the most relavent function to study is printBufferToScreen(). 
+
+Other notes: 
+ This is a simple demonstration of the SDI-12 library for Arduino.
+ 
+ It discovers the address of all sensors active on a single bus and takes measurements from them.
+ 
+ Every SDI-12 device is different in the time it takes to take a measurement, and the amount of data it returns.
+ 
+ This sketch will not serve every sensor type, but it will likely be helpful in getting you started.  
+ 
+ Each sensor should have a unique address already - if not, multiple sensors may respond simultaenously
+ to the same request and the output will not be readable by the Arduino. 
+ 
+ To address a sensor, please see Example B: b_address_change.ino
+ 
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/arduino-SDI-12
+ 
+ The circuit: You  may use one or more pre-adressed sensors.  
+ See:
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_usb_multiple_sensors.png
+ or
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb_multiple_sensors.png
+ or
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_usb.png
+ or
+ https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
+ 
+ Written by Kevin M. Smith in 2013. 
+ Contact: SDI12@ethosengineering.org
+ */
+
+
+#include <SDI12.h>
+
+#define DATAPIN 9         // change to the proper pin
+SDI12 mySDI12(DATAPIN); 
+
+boolean flip = 1;             // variable that alternates output type back and forth. 
+
+// The code below alternates printing in non-parsed, and parsed mode. 
+//
+// The parseInt() and parseFloat() functions will timeout if they do not
+// find a candidate INT or FLOAT. 
+//
+// The value returned when a TIMEOUT is encountered
+// is set in SDI12.cpp by default to -9999. 
+//
+// You can change the default setting directly:
+//    mySDI12.TIMEOUT = (int) newValue
+// The value of TIMEOUT should not be a possible data value. 
+//
+// You should always check for timeouts before interpreting data, as 
+// shown in the example below. 
+
+void printBufferToScreen(){
+
+  flip = !flip; // flip the switch
+  
+  if(flip){    // print out the buffer as a string, as in example D
+    boolean firstPass = true;
+    String buffer = "";
+    mySDI12.read(); // consume address
+    while(mySDI12.available()){
+      char c = mySDI12.read();
+      if(c == '+' || c == '-'){
+        buffer += ',';   
+        if(c == '-') buffer += '-'; 
+      } 
+      else {
+        buffer += c;  
+      }
+      firstPass = false; 
+      delay(100); 
+    }
+    Serial.print(buffer);
+  } 
+  else {       // parse buffer for floats and multiply by 2 before printing
+    while(mySDI12.available()){
+        float that = mySDI12.parseFloat();
+        if(that != mySDI12.TIMEOUT){    //check for timeout
+          float doubleThat = that * 2;   
+          Serial.print(",");
+          Serial.print(that);
+          Serial.print(" x 2 = "); 
+          Serial.print(doubleThat);
+        }
+    } 
+    Serial.println(); 
+  }
+}
+
+// keeps track of active addresses
+// each bit represents an address:
+// 1 is active (taken), 0 is inactive (available)
+// setTaken('A') will set the proper bit for sensor 'A'
+byte addressRegister[8] = { 
+  0B00000000, 
+  0B00000000, 
+  0B00000000, 
+  0B00000000, 
+  0B00000000, 
+  0B00000000, 
+  0B00000000, 
+  0B00000000 
+}; 
+
+
+void setup(){
+  Serial.begin(9600); 
+  mySDI12.begin(); 
+  delay(500); // allow things to settle
+
+  Serial.println("Scanning all addresses, please wait..."); 
+  /*
+      Quickly Scan the Address Space
+   */
+
+  for(byte i = '0'; i <= '9'; i++) if(checkActive(i)) setTaken(i);   // scan address space 0-9
+
+  for(byte i = 'a'; i <= 'z'; i++) if(checkActive(i)) setTaken(i);   // scan address space a-z
+
+  for(byte i = 'A'; i <= 'Z'; i++) if(checkActive(i)) setTaken(i);   // scan address space A-Z
+
+  /*
+      See if there are any active sensors. 
+   */
+  boolean found = false; 
+
+  for(byte i = 0; i < 62; i++){
+    if(isTaken(i)){
+      found = true;
+      break;
+    }
+  }
+
+  if(!found) {
+    Serial.println("No sensors found, please check connections and restart the Arduino."); 
+    while(true);
+  } // stop here
+
+    Serial.println(); 
+  Serial.println("Time Elapsed (s), Sensor Address and ID, Measurement 1, Measurement 2, ... etc."); 
+  Serial.println("-------------------------------------------------------------------------------");
+}
+
+void loop(){
+
+  // scan address space 0-9
+  for(char i = '0'; i <= '9'; i++) if(isTaken(i)){
+    Serial.print(millis()/1000);
+    Serial.print(",");
+    printInfo(i);
+    takeMeasurement(i);
+  }
+
+  // scan address space a-z
+  for(char i = 'a'; i <= 'z'; i++) if(isTaken(i)){
+    Serial.print(millis()/1000);
+    Serial.print(",");
+    printInfo(i); 
+    takeMeasurement(i);
+  } 
+
+  // scan address space A-Z
+  for(char i = 'A'; i <= 'Z'; i++) if(isTaken(i)){
+    Serial.print(millis()/1000);
+    Serial.print(",");
+    printInfo(i);   
+    takeMeasurement(i);
+  };   
+
+  delay(10000); // wait ten seconds between measurement attempts. 
+
+}
+
+void takeMeasurement(char i){
+  String command = ""; 
+  command += i;
+  command += "M!"; // SDI-12 measurement command format  [address]['M'][!]
+  mySDI12.sendCommand(command); 
+  while(!mySDI12.available()>5); // wait for acknowlegement with format [address][ttt (3 char, seconds)][number of measurments available, 0-9]
+  delay(100); 
+
+  mySDI12.read(); //consume address
+
+  // find out how long we have to wait (in seconds).
+  int wait = 0; 
+  wait += 100 * mySDI12.read()-'0';
+  wait += 10 * mySDI12.read()-'0';
+  wait += 1 * mySDI12.read()-'0';
+
+  mySDI12.read(); // ignore # measurements, for this simple examlpe
+  mySDI12.read(); // ignore carriage return
+  mySDI12.read(); // ignore line feed
+
+    long timerStart = millis(); 
+  while((millis() - timerStart) > (1000 * wait)){
+    if(mySDI12.available()) break;                //sensor can interrupt us to let us know it is done early
+  }
+
+  // in this example we will only take the 'DO' measurement  
+  mySDI12.flush(); 
+  command = "";
+  command += i;
+  command += "D0!"; // SDI-12 command to get data [address][D][dataOption][!]
+  mySDI12.sendCommand(command);
+  while(!mySDI12.available()>1); // wait for acknowlegement  
+  delay(300); // let the data transfer
+  printBufferToScreen(); 
+  mySDI12.flush(); 
+}
+
+
+// this checks for activity at a particular address     
+// expects a char, '0'-'9', 'a'-'z', or 'A'-'Z'
+boolean checkActive(char i){              
+
+  String myCommand = "";
+  myCommand = "";
+  myCommand += (char) i;                 // sends basic 'acknowledge' command [address][!]
+  myCommand += "!";
+
+  for(int j = 0; j < 3; j++){            // goes through three rapid contact attempts
+    mySDI12.sendCommand(myCommand);
+    if(mySDI12.available()>1) break;
+    delay(30); 
+  }
+  if(mySDI12.available()>2){       // if it hears anything it assumes the address is occupied
+    mySDI12.flush(); 
+    return true;
+  } 
+  else {   // otherwise it is vacant. 
+    mySDI12.flush(); 
+  }
+  return false; 
+}
+
+
+// this sets the bit in the proper location within the addressRegister
+// to record that the sensor is active and the address is taken. 
+boolean setTaken(byte i){          
+  boolean initStatus = isTaken(i);
+  i = charToDec(i); // e.g. convert '0' to 0, 'a' to 10, 'Z' to 61. 
+  byte j = i / 8;   // byte #
+  byte k = i % 8;   // bit #
+  addressRegister[j] |= (1 << k); 
+  return !initStatus; // return false if already taken
+}
+
+// THIS METHOD IS UNUSED IN THIS EXAMPLE, BUT IT MAY BE HELPFUL. 
+// this unsets the bit in the proper location within the addressRegister
+// to record that the sensor is active and the address is taken. 
+boolean setVacant(byte i){
+  boolean initStatus = isTaken(i);
+  i = charToDec(i); // e.g. convert '0' to 0, 'a' to 10, 'Z' to 61. 
+  byte j = i / 8;   // byte #
+  byte k = i % 8;   // bit #
+  addressRegister[j] &= ~(1 << k); 
+  return initStatus; // return false if already vacant
+}
+
+
+// this quickly checks if the address has already been taken by an active sensor           
+boolean isTaken(byte i){         
+  i = charToDec(i); // e.g. convert '0' to 0, 'a' to 10, 'Z' to 61. 
+  byte j = i / 8;   // byte #
+  byte k = i % 8;   // bit #
+  return addressRegister[j] & (1<<k); // return bit status
+}
+
+// gets identification information from a sensor, and prints it to the serial port
+// expects a character between '0'-'9', 'a'-'z', or 'A'-'Z'. 
+char printInfo(char i){
+  int j; 
+  String command = "";
+  command += (char) i; 
+  command += "I!";
+  mySDI12.sendCommand(command);
+  delay(30); 
+
+  while(mySDI12.available()){
+    char c = mySDI12.read();
+    if((c!='\n') && (c!='\r')) Serial.write(c);
+    delay(5); 
+  } 
+}
+
+// converts allowable address characters '0'-'9', 'a'-'z', 'A'-'Z',
+// to a decimal number between 0 and 61 (inclusive) to cover the 62 possible addresses
+byte charToDec(char i){
+  if((i >= '0') && (i <= '9')) return i - '0';
+  if((i >= 'a') && (i <= 'z')) return i - 'a' + 10;
+  if((i >= 'A') && (i <= 'Z')) return i - 'A' + 37;
+}
+
+// THIS METHOD IS UNUSED IN THIS EXAMPLE, BUT IT MAY BE HELPFUL. 
+// maps a decimal number between 0 and 61 (inclusive) to 
+// allowable address characters '0'-'9', 'a'-'z', 'A'-'Z',
+char decToChar(byte i){
+  if((i >= 0) && (i <= 9)) return i + '0';
+  if((i >= 10) && (i <= 36)) return i + 'a' - 10;
+  if((i >= 37) && (i <= 62)) return i + 'A' - 37;
+}
+
+

--- a/examples/e_simple_parsing/e_simple_parsing.ino
+++ b/examples/e_simple_parsing/e_simple_parsing.ino
@@ -1,5 +1,9 @@
 /*
-Example E: This example demonstrates the ability to parse integers and floats from the buffer. 
+########################
+#        OVERVIEW      #
+########################
+
+ Example E: This example demonstrates the ability to parse integers and floats from the buffer. 
 
  It is based closely on example D, however, every other time it prints out data, it multiplies the data by a factor of 2. 
  
@@ -27,11 +31,13 @@ Other notes:
  to the same request and the output will not be readable by the Arduino. 
  
  To address a sensor, please see Example B: b_address_change.ino
+
+#########################
+#      THE CIRCUIT      #
+#########################
  
- The SDI-12 specification is available at: http://www.sdi-12.org/
- The library is available at: https://github.com/StroudCenter/arduino-SDI-12
+ You  may use one or more pre-adressed sensors.  
  
- The circuit: You  may use one or more pre-adressed sensors.  
  See:
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/basic_setup_usb_multiple_sensors.png
  or
@@ -41,9 +47,33 @@ Other notes:
  or
  https://raw.github.com/Kevin-M-Smith/SDI-12-Circuit-Diagrams/master/compat_setup_usb.png
  
+###########################
+#      COMPATIBILITY      #
+###########################
+ 
+ This library requires the use of pin change interrupts (PCINT). 
+ Not all Arduino boards have the same pin capabilities. 
+ The known compatibile pins for common variants are shown below.
+ 
+ Arduino Uno: 	All pins. 
+
+ Arduino Mega or Mega 2560:
+ 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), 
+ A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69).
+
+ Arduino Leonardo:
+ 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)
+
+#########################
+#      RESOURCES        #
+#########################
+
  Written by Kevin M. Smith in 2013. 
  Contact: SDI12@ethosengineering.org
- */
+
+ The SDI-12 specification is available at: http://www.sdi-12.org/
+ The library is available at: https://github.com/StroudCenter/Arduino-SDI-12
+*/
 
 
 #include <SDI12.h>


### PR DESCRIPTION
By inheriting from the Arduino Stream class the SDI-12 library now has access to the parseFloat() and parseInt() functions. This allows the Arduino to more easily manipulate incoming data. The compiled size of the library is not significantly changed. There are no known cons or downsides to this change. 

An additional example has been added to demonstrate the functionality. 

Please review the Stream branch to see if it is ready to commit. 